### PR TITLE
noDistortion option to prevent image from getting distorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A `ThumbnailService` dependency can be injected into a controller.
         - `height`: number (defaults to 100)
         - `returnType`: 'blob' (defaults to 'base64')
         - `type`: 'image/jpeg' (defaults to 'image/png')
-        - `noDistortion`: boolean. If true, the image will not get distorted. (defaults to false)
-        - `encoderOptions`: A number between 0 and 1 indicating image quality if the requested type is 'image/jpeg' or 'image/webp'.
+        - `noDistortion`: boolean. If true, the image will not get distorted. (defaults to false)
+        - `encoderOptions`: A number between 0 and 1 indicating image quality if the requested type is 'image/jpeg' or 'image/webp'.
 
 - Returns: a promise that resolves with a base64 string or blob

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A `ThumbnailService` dependency can be injected into a controller.
         - `height`: number (defaults to 100)
         - `returnType`: 'blob' (defaults to 'base64')
         - `type`: 'image/jpeg' (defaults to 'image/png')
-        - `encoderOptions`: A number between 0 and 1 indicating image quality if the requested type is 'image/jpeg' or 'image/webp'.
+        - `noDistortion`: boolean. If true, the image will not get distorted. (defaults to false)
+        - `encoderOptions`: A number between 0 and 1 indicating image quality if the requested type is 'image/jpeg' or 'image/webp'.
 
 - Returns: a promise that resolves with a base64 string or blob

--- a/angular-thumbnail.js
+++ b/angular-thumbnail.js
@@ -17,6 +17,10 @@ angular.module('ui.thumbnail', [])
 
         opts = opts || {};
 
+        if(!opts.noDistortion){
+          opts.noDistortion = false;
+        }
+        
         this.load(src, opts).loaded.then(
           function success(canvas) {
             if (opts.returnType === 'blob') {
@@ -58,20 +62,29 @@ angular.module('ui.thumbnail', [])
           // creation is done
           created: $q.when(canvas),
           // wait for it
-          loaded: this.draw(canvas, src)
+          loaded: this.draw(canvas, src, opts.noDistortion)
         };
       },
 
-      draw: function draw(canvas, src) {
+      draw: function draw(canvas, src, noDistortion) {
         var deferred = $q.defer();
+        var self = this;
 
         var ctx = canvas.getContext('2d');
         // it seems that we cannot reuse image instance for drawing
         var img = new Image();
 
         img.onload = function onload() {
+          
+          var resized = canvas;
+          if(noDistortion){
+            resized = self.resizeImage(img, canvas);
+            canvas = self.updateCanvas(canvas, resized);
+            ctx = canvas.getContext('2d');
+          }
+          
           // designated canvas dimensions should have been set
-          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          ctx.drawImage(img, 0, 0, resized.width, resized.height);
 
           // loading is done
           deferred.resolve(canvas);
@@ -80,6 +93,30 @@ angular.module('ui.thumbnail', [])
         img.src = src;
 
         return deferred.promise;
+      },
+
+      resizeImage: function resizeImage(img, canvas){
+        var imageRatio = img.width / img.height;
+        
+        var newHeight = canvas.width / imageRatio;
+        var newWidth = canvas.height * imageRatio;
+        
+        var heightDiff = newHeight - canvas.height;
+        var widthDiff = newWidth - canvas.width;
+        
+        if (widthDiff >= heightDiff) {
+            return dimensions(canvas.width, canvas.width / imageRatio );
+        } else {
+          return dimensions(canvas.height * imageRatio, canvas.height);
+        }
+
+        function dimensions(width, height){
+          return {
+            width: width, 
+            height: height
+          };
+        }
+
       },
 
       createCanvas: function createCanvas(opts) {

--- a/angular-thumbnail.js
+++ b/angular-thumbnail.js
@@ -17,7 +17,7 @@ angular.module('ui.thumbnail', [])
 
         opts = opts || {};
 
-        if(!opts.noDistortion){
+        if (!opts.noDistortion) {
           opts.noDistortion = false;
         }
         
@@ -77,7 +77,7 @@ angular.module('ui.thumbnail', [])
         img.onload = function onload() {
           
           var resized = canvas;
-          if(noDistortion){
+          if (noDistortion ){
             resized = self.resizeImage(img, canvas);
             canvas = self.updateCanvas(canvas, resized);
             ctx = canvas.getContext('2d');
@@ -95,7 +95,7 @@ angular.module('ui.thumbnail', [])
         return deferred.promise;
       },
 
-      resizeImage: function resizeImage(img, canvas){
+      resizeImage: function resizeImage(img, canvas) {
         var imageRatio = img.width / img.height;
         
         var newHeight = canvas.width / imageRatio;
@@ -105,7 +105,7 @@ angular.module('ui.thumbnail', [])
         var widthDiff = newWidth - canvas.width;
         
         if (widthDiff >= heightDiff) {
-            return dimensions(canvas.width, canvas.width / imageRatio );
+          return dimensions(canvas.width, canvas.width / imageRatio);
         } else {
           return dimensions(canvas.height * imageRatio, canvas.height);
         }
@@ -116,7 +116,6 @@ angular.module('ui.thumbnail', [])
             height: height
           };
         }
-
       },
 
       createCanvas: function createCanvas(opts) {


### PR DESCRIPTION
When creating the thumbnail with an arbitrary {width, height}, the image can get distorted by forcing the resizing to these specific dimensions. 
So, I put the 'noDistortion' option. If true, means the image will be resized to the most approximate dimension which does not distort the image. 